### PR TITLE
Fix for GitHub Issues 220 and 222

### DIFF
--- a/src/AasxCsharpLibrary/Extensions/ExtendConceptDescription.cs
+++ b/src/AasxCsharpLibrary/Extensions/ExtendConceptDescription.cs
@@ -207,13 +207,14 @@ namespace Extensions
 
             if (sourceConceptDescription.IsCaseOf != null && sourceConceptDescription.IsCaseOf.Count != 0)
             {
-                if (conceptDescription.IsCaseOf == null)
-                {
-                    conceptDescription.IsCaseOf = new List<IReference>();
-                }
+                
                 foreach (var caseOf in sourceConceptDescription.IsCaseOf)
                 {
-                    conceptDescription.IsCaseOf.Add(ExtensionsUtil.ConvertReferenceFromV10(caseOf, ReferenceTypes.ModelReference));
+                    if (!caseOf.IsEmpty)
+                    {
+                        conceptDescription.IsCaseOf ??= new List<IReference>();
+                        conceptDescription.IsCaseOf.Add(ExtensionsUtil.ConvertReferenceFromV10(caseOf, ReferenceTypes.ModelReference)); 
+                    }
                 }
             }
 
@@ -242,13 +243,14 @@ namespace Extensions
 
             if (srcCD.IsCaseOf != null && srcCD.IsCaseOf.Count != 0)
             {
-                if (cd.IsCaseOf == null)
-                {
-                    cd.IsCaseOf = new List<IReference>();
-                }
+                
                 foreach (var caseOf in srcCD.IsCaseOf)
                 {
-                    cd.IsCaseOf.Add(ExtensionsUtil.ConvertReferenceFromV20(caseOf, ReferenceTypes.ModelReference));
+                    if (!caseOf.IsEmpty)
+                    {
+                        cd.IsCaseOf ??= new List<IReference>();
+                        cd.IsCaseOf.Add(ExtensionsUtil.ConvertReferenceFromV20(caseOf, ReferenceTypes.ModelReference)); 
+                    }
                 }
             }
 

--- a/src/AasxServerBlazor/Properties/launchSettings.json
+++ b/src/AasxServerBlazor/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",
-      "commandLineArgs": "--rest --port 51710 --data-path C:\\MIHO\\Develop\\Aasx\\repo --edit --secret-string=123",
+      "commandLineArgs": "--port 51710 --data-path C:\\MIHO\\Develop\\Aasx\\repo --edit --secret-string=123",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/AasxServerBlazor/startForDemo.bat
+++ b/src/AasxServerBlazor/startForDemo.bat
@@ -1,1 +1,1 @@
-AasxServerBlazor.exe --rest --no-security --data-path aasxs
+AasxServerBlazor.exe --no-security --data-path aasxs

--- a/src/AasxServerBlazor/startForDemo.sh
+++ b/src/AasxServerBlazor/startForDemo.sh
@@ -1,1 +1,1 @@
-dotnet AasxServerBlazor.dll --rest --no-security --data-path ./aasxs --host 0.0.0.0 $OPTIONSAASXSERVER
+dotnet AasxServerBlazor.dll --no-security --data-path ./aasxs --host 0.0.0.0 $OPTIONSAASXSERVER

--- a/src/AasxServerStandardBib/Program.cs
+++ b/src/AasxServerStandardBib/Program.cs
@@ -1582,27 +1582,14 @@ namespace AasxServer
             var rootCommand = new RootCommand("serve AASX packages over different interfaces")
             {
                 new Option<string>(
-                    new[] {"--host", "-h"},
+                    new[] {"--host"},
                     () => "localhost",
                     "Host which the server listens on"),
-
-                new Option<string>(
-                    new[] {"--port", "-p"},
-                    ()=>"51310",
-                    "Port which the server listens on"),
-
-                new Option<bool>(
-                    new[] {"--https"},
-                    "If set, opens SSL connections. " +
-                    "Make sure you bind a certificate to the port before."),
 
                 new Option<string>(
                     new[] {"--data-path"},
                     "Path to where the AASXs reside"),
 
-                new Option<bool>(
-                    new[] {"--rest"},
-                    "If set, starts the REST server"),
 
                 new Option<bool>(
                     new[] {"--opc"},
@@ -1621,15 +1608,6 @@ namespace AasxServer
                     "If set, starts an OPC client and refreshes on the given period " +
                     "(in milliseconds)"),
 
-                new Option<string[]>(
-                    new[] {"--connect"},
-                    "If set, connects to AAS connect server. " +
-                    "Given as a comma-separated-values (server, node name, period in milliseconds) or " +
-                    "as a flag (in which case it connects to a default server).")
-                {
-                    Argument = new Argument<string[]>{ Arity = ArgumentArity.ZeroOrOne }
-                },
-
                 new Option<string>(
                     new[] {"--proxy-file"},
                     "If set, parses the proxy information from the given proxy file"),
@@ -1645,10 +1623,6 @@ namespace AasxServer
                 new Option<string>(
                     new[] {"--name"},
                     "Name of the server"),
-
-                new Option<string>(
-                    new[] {"--external-rest"},
-                    "external name of the server"),
 
                 new Option<string>(
                     new[] {"--external-blazor"},


### PR DESCRIPTION
# Description

This PR includes fixes for GitHub Issues #220 and #222. 

[a] If a V2 AASX file consists of a concept description with empty IsCaseOf reference, V3 conversion and thereby file APIs fail due to constraints in xml de/serializations from aas-core-sdk. Thus, if V1 or V2 AASX files have such empty IsCaseOf reference, there are skipped from the conversion.

[b] Additionally, the server was showing a few command line arguments (-h, -p, -rest, -https, -external-rest ), which are not supported anymore. Hence, with this PR such arguments are removed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
[a] was successfully tested with GetAASXFile Api
[b] was tested with commandline execution of server with help option.

## Screenshots (if appropriate):

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
